### PR TITLE
Rename time series to budget-vs-actual

### DIFF
--- a/budget-vs-actual/national/pipeline-spec.yaml
+++ b/budget-vs-actual/national/pipeline-spec.yaml
@@ -1,5 +1,5 @@
-expenditure-time-series:
-  title: Expenditure Time Series
+budget-vs-actual-national:
+  title: National budgeted and actual expenditure
   description: Combined dataset which consists of ENE, AENE and ARE datasets of all financial years.
   pipeline:
     # ENE must be loaded prior to loading AR(E) otherwise it results in a ValidationError
@@ -207,8 +207,8 @@ expenditure-time-series:
           - aene-2017-18
           - aene-2018-19
         target:
-          name: expenditure-time-series
-          path: data/expenditure-time-series.csv
+          name: budget-vs-actual-national
+          path: data/budget-vs-actual-national.csv
         fields:
           Budget Phase: ['budget phase', 'budget_phase']
           Department: ['department']
@@ -232,7 +232,7 @@ expenditure-time-series:
     - run: add_computed_field
       parameters:
         resources:
-          - expenditure-time-series
+          - budget-vs-actual-national
         fields:
           - operation: format
             target: Government

--- a/budget-vs-actual/provincial/pipeline-spec.yaml
+++ b/budget-vs-actual/provincial/pipeline-spec.yaml
@@ -79,7 +79,7 @@ budget-vs-actual-provincial:
           - epre-2015-16
         target:
           name: budget-vs-actual-provincial
-          path: data/.csv
+          path: data/budget-vs-actual-provincial.csv
         fields:
           Budget Phase: ['budget phase', 'budget_phase']
           Department: ['department']

--- a/budget-vs-actual/provincial/pipeline-spec.yaml
+++ b/budget-vs-actual/provincial/pipeline-spec.yaml
@@ -1,4 +1,4 @@
-:
+budget-vs-actual-provincial:
   title: Provincial budgeted and actual expenditure
   description: Combined dataset which consists of EPRE of all financial years.
   pipeline:
@@ -78,7 +78,7 @@
           - epre-2016-17
           - epre-2015-16
         target:
-          name:
+          name: budget-vs-actual-provincial
           path: data/.csv
         fields:
           Budget Phase: ['budget phase', 'budget_phase']

--- a/budget-vs-actual/provincial/pipeline-spec.yaml
+++ b/budget-vs-actual/provincial/pipeline-spec.yaml
@@ -1,5 +1,5 @@
-provincial-time-series:
-  title: Provincial Time Series
+:
+  title: Provincial budgeted and actual expenditure
   description: Combined dataset which consists of EPRE of all financial years.
   pipeline:
 
@@ -78,8 +78,8 @@ provincial-time-series:
           - epre-2016-17
           - epre-2015-16
         target:
-          name: provincial-time-series
-          path: data/provincial-time-series.csv
+          name:
+          path: data/.csv
         fields:
           Budget Phase: ['budget phase', 'budget_phase']
           Department: ['department']


### PR DESCRIPTION
because it's more about the comparison than the ENE and EPRE datasets
which are more about the time series